### PR TITLE
Fix typo aleternativeNamesSet -> alternativeNamesSet

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -195,14 +195,14 @@ class ServerlessCloudfrontDistributionCertificate {
       );
       const certificateDetails = await Promise.all(certificateDetailPromises);
       certificate = certificateDetails.find((certificateDetail) => {
-        const aleternativeNamesSet = new Set(
+        const alternativeNamesSet = new Set(
           certificateDetail.Certificate.SubjectAlternativeNames,
         );
         this.serverless.cli.log(
           `Checking: ${certificateDetail.Certificate.DomainName}`,
         );
 
-        return !alternativeNames.some((aN) => !aleternativeNamesSet.has(aN));
+        return !alternativeNames.some((aN) => !alternativeNamesSet.has(aN));
       });
     }
 


### PR DESCRIPTION
Not very dramatic, but a small improvement.