### PR TITLE
Ability to config ViewerCertificate's MinimumProtocolVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ custom:
       - "server.example.com"
       - "doggo.example.com"
     cloudFront: CloudFrontDistribution
+    minimumProtocolVersion: TLSv1.2_2018
 ```
 
-Where `domainNames` are domains for which ssl certificate should be generated and `cloudFront` is the logical name of your CloudFront distribution.
+Where `domainNames` are domains for which ssl certificate should be generated, `cloudFront` is the logical name of your CloudFront distribution, and `minimumProtocolVersion` is the ViewerCertificate's [MinimumProtocolVersion](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ViewerCertificate.html#cloudfront-Type-ViewerCertificate-MinimumProtocolVersion) setting (optional).
 
 ## Note
 

--- a/ServerlessInstance.d.ts
+++ b/ServerlessInstance.d.ts
@@ -18,6 +18,7 @@ export interface ServerlessInstance {
         domainName: string;
         domainNames: string[];
         cloudFront: string;
+        minimumProtocolVersion: string;
       };
     };
   };

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ class ServerlessCloudfrontDistributionCertificate {
   private options: ServerlessOptions;
   private domains: string[];
   private cerArn: Arn;
+  private minProtocolVersion: string;
   private acm: aws.ACM;
   private route53: aws.Route53;
   private cloudFront: string;
@@ -44,6 +45,7 @@ class ServerlessCloudfrontDistributionCertificate {
     }
 
     this.cloudFront = this.serverless.service.custom.cfdDomain.cloudFront;
+    this.minProtocolVersion = this.serverless.service.custom.cfdDomain.minimumProtocolVersion;
 
     await this.createCert();
 
@@ -245,6 +247,13 @@ class ServerlessCloudfrontDistributionCertificate {
       AcmCertificateArn: this.cerArn,
       SslSupportMethod: "sni-only",
     };
+
+    if (this.minProtocolVersion) {
+      template.Resources[
+        this.cloudFront
+      ].Properties.DistributionConfig
+        .ViewerCertificate.MinimumProtocolVersion = this.minProtocolVersion;
+    }
   }
 }
 


### PR DESCRIPTION
This plugin overwrites the CloudFront distribution config's
ViewerCertificate settings, which overrides any pre-existing
MinimumProtocolVersion configuration that may or may not exist in the
serverless config's Resource section.  This enhancement provides the
only way to specify the MinimumProtocolVersion config when generating
the distribution's ViewerCertificate settings via this plugin.